### PR TITLE
fix: auto-detect test service for --exit-code-from

### DIFF
--- a/__tests__/getTestService.test.js
+++ b/__tests__/getTestService.test.js
@@ -1,0 +1,19 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getTestService } from '../src/index.js';
+
+const makeCompose = (services) => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'compose-test-'));
+  const lines = services.map((s) => `  ${s}:\n    command: echo 1`).join('\n');
+  writeFileSync(path.join(dir, 'docker-compose.yml'), `services:\n${lines}`);
+  return dir;
+};
+
+test('returns "test" when test service exists', () => {
+  expect(getTestService(makeCompose(['app', 'test']))).toBe('test');
+});
+
+test('returns "app" when no test service', () => {
+  expect(getTestService(makeCompose(['app']))).toBe('app');
+});

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ const prepareProject = async (options) => {
   });
 };
 
-const getTestService = (projectSourcePath) => {
+export const getTestService = (projectSourcePath) => {
   const composePath = path.join(projectSourcePath, 'docker-compose.yml');
   const composeData = yaml.load(fs.readFileSync(composePath).toString());
   return composeData?.services?.test ? 'test' : 'app';

--- a/src/index.js
+++ b/src/index.js
@@ -128,15 +128,22 @@ const prepareProject = async (options) => {
   });
 };
 
+const getTestService = (projectSourcePath) => {
+  const composePath = path.join(projectSourcePath, 'docker-compose.yml');
+  const composeData = yaml.load(fs.readFileSync(composePath).toString());
+  return composeData?.services?.test ? 'test' : 'app';
+};
+
 const check = async ({ projectSourcePath, codePath, projectMember }) => {
   const sourceLang = projectMember.project.language;
   checkPackageName(codePath, sourceLang);
   const options = { cwd: projectSourcePath };
   // NOTE: Installing dependencies is part of testing the project.
   await exec.exec('docker compose', ['run', 'app', 'make', 'setup'], options);
+  const testService = getTestService(projectSourcePath);
   await exec.exec(
     'docker compose',
-    ['-f', 'docker-compose.yml', 'up', '--abort-on-container-exit'],
+    ['-f', 'docker-compose.yml', 'up', '--abort-on-container-exit', '--exit-code-from', testService],
     options,
   );
 


### PR DESCRIPTION
## Проблема

Проекты с отдельным `test`-контейнером получали ложные `FAILED` в CI.

**Сценарий:** `test` завершается с кодом 0 (тесты прошли) → Docker Compose убивает `app`, `caddy`, `db` через SIGTERM → они возвращают ненулевой код → без `--exit-code-from` Compose сообщает об ошибке → CI падает.

Цепочки зависимостей в таких проектах: `db → app → caddy → test`.

## Решение

Добавлена функция `getTestService()`, которая читает `docker-compose.yml` и возвращает имя сервиса для `--exit-code-from`:
- есть сервис `test` → `'test'`
- нет → `'app'` (текущее поведение для 66% проектов)

```js
const getTestService = (projectSourcePath) => {
  const composePath = path.join(projectSourcePath, 'docker-compose.yml');
  const composeData = yaml.load(fs.readFileSync(composePath).toString());
  return composeData?.services?.test ? 'test' : 'app';
};
```

`js-yaml` уже был импортирован в `src/index.js`.

## Контекст

Из 96 проектов Hexlet (ru/en/es):
- **63 (66%)** — один сервис `app`, тесты запускаются внутри него → `--exit-code-from app`
- **~33 (34%)** — отдельный сервис `test` → `--exit-code-from test`

Миграция проектов не требуется — автодетект по имени сервиса покрывает оба паттерна.

## Тесты

- [ ] Все 13 существующих тестов проходят (`make test`)
- [ ] Проверить на реальном проекте с `test`-контейнером (например, `python_l4_task_manager_project`)